### PR TITLE
feat: add the new MO property m_ParentEmitterId

### DIFF
--- a/Source/Entities/HDFirearm.cpp
+++ b/Source/Entities/HDFirearm.cpp
@@ -776,6 +776,9 @@ void HDFirearm::Update() {
 						}
 					}
 
+					// Assign the HDFIrearm as this particle's ParentEmitter
+					pParticle->SetParentEmitterId(this->m_MOID);
+
 					// Set the fired particle to not hit this HeldDevice's parent, if applicable
 					if (m_FireIgnoresThis)
 						pParticle->SetWhichMOToNotHit(this, 1.0f);

--- a/Source/Entities/MovableObject.cpp
+++ b/Source/Entities/MovableObject.cpp
@@ -77,6 +77,7 @@ void MovableObject::Clear() {
 	m_ToSettle = false;
 	m_ToDelete = false;
 	m_HUDVisible = true;
+	m_ParentEmitterId = g_NoMOID;
 	m_IsTraveling = false;
 	m_AllLoadedScripts.clear();
 	m_FunctionsAndScripts.clear();
@@ -222,6 +223,7 @@ int MovableObject::Create(const MovableObject& reference) {
 	m_MissionCritical = reference.m_MissionCritical;
 	m_CanBeSquished = reference.m_CanBeSquished;
 	m_HUDVisible = reference.m_HUDVisible;
+	m_ParentEmitterId = reference.m_ParentEmitterId;
 	m_PostEffectEnabled = reference.m_PostEffectEnabled;
 
 	m_ForceIntoMasterLuaState = reference.m_ForceIntoMasterLuaState;

--- a/Source/Entities/MovableObject.h
+++ b/Source/Entities/MovableObject.h
@@ -535,12 +535,20 @@ namespace RTE {
 		bool CanBeSquished() const { return m_CanBeSquished; }
 
 		/// Tells whether this Actor's HUD is drawn or not.
-		/// @return Whether this' HUD gets drawn or not.
+		/// @param A boolean value indicating if this Actor's HUD should be visible or not
 		void SetHUDVisible(bool visible) { m_HUDVisible = visible; }
 
 		/// Tells whether this Actor's HUD is drawn or not.
 		/// @return Whether this' HUD gets drawn or not.
 		bool GetHUDVisible() const { return m_HUDVisible; }
+
+		/// Assign this MO a parent MO that created it.
+		/// @param A MOID of the MO said to have created/emitted this MO
+		void SetParentEmitterId(MOID parentMOID) { m_ParentEmitterId = parentMOID; }
+
+		/// Returns the parent MO that created this MO.
+		/// @return The MOID of a MO that created this MO, or nullptr
+		MOID GetParentEmitterId() const { return m_ParentEmitterId; }
 
 		/// Indicates whether this MO is moving or rotating stupidly fast in a way
 		/// that will screw up the simulation.
@@ -867,7 +875,7 @@ namespace RTE {
 		virtual void PostTravel();
 
 		/// Update called prior to controller update. Ugly hack. Supposed to be done every frame.
-		virtual void PreControllerUpdate(){};
+		virtual void PreControllerUpdate() {};
 
 		/// Updates this MovableObject. Supposed to be done every frame. This also
 		/// applies and clear the accumulated impulse forces (impulses), and the
@@ -1223,6 +1231,8 @@ namespace RTE {
 		bool m_ToDelete;
 		// To draw this guy's HUD or not
 		bool m_HUDVisible;
+		/// The MOID of the MO that cmitted or created this MO, eg: HDFirearm that emitted the particle.
+		MOID m_ParentEmitterId;
 
 		bool m_IsTraveling; //!< Prevents self-intersection while traveling.
 

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -723,9 +723,8 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, HeldDevice) {
 	    .def("RemovePickupableByPresetName", &HeldDevice::RemovePickupableByPresetName)
 
 	    .enum_("HeldDeviceHotkeyType")[luabind::value("PRIMARYHOTKEY", HeldDeviceHotkeyType::PRIMARYHOTKEY),
-	                         luabind::value("AUXILIARYHOTKEY", HeldDeviceHotkeyType::AUXILIARYHOTKEY),
-	                         luabind::value("HELDDEVICEHOTKEYTYPECOUNT", HeldDeviceHotkeyType::HELDDEVICEHOTKEYTYPECOUNT)];
-	
+	                                   luabind::value("AUXILIARYHOTKEY", HeldDeviceHotkeyType::AUXILIARYHOTKEY),
+	                                   luabind::value("HELDDEVICEHOTKEYTYPECOUNT", HeldDeviceHotkeyType::HELDDEVICEHOTKEYTYPECOUNT)];
 }
 
 LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, Leg) {
@@ -955,6 +954,7 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, MovableObject) {
 	    .property("ToDelete", &MovableObject::ToDelete, &MovableObject::SetToDelete)
 	    .property("MissionCritical", &MovableObject::IsMissionCritical, &MovableObject::SetMissionCritical)
 	    .property("HUDVisible", &MovableObject::GetHUDVisible, &MovableObject::SetHUDVisible)
+	    .property("ParentEmitterId", &MovableObject::GetParentEmitterId, &MovableObject::SetParentEmitterId)
 	    .property("PinStrength", &MovableObject::GetPinStrength, &MovableObject::SetPinStrength)
 	    .property("RestThreshold", &MovableObject::GetRestThreshold, &MovableObject::SetRestThreshold)
 	    .property("DamageOnCollision", &MovableObject::DamageOnCollision, &MovableObject::SetDamageOnCollision)


### PR DESCRIPTION
ParentEmitterId stores the MOID of the MO considered to have created/emitted a given MO. Currently only set when an HDFirearm emits a particle, can be used to get a reference to the parent firearm in bullet scripts.

Adds a new property, defaulted to `g_NoMOID`.
Adds LUA property bindings under `ParentEmitterId`